### PR TITLE
Update CUDA image for CUDA 10.2 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:10.2-base-ubuntu18.04
+FROM nvidia/cuda:10.2-devel-ubuntu18.04
 
 RUN apt-get update
 RUN apt-get install -y git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:latest
+FROM nvidia/cuda:10.2-base-ubuntu18.04
 
 RUN apt-get update
 RUN apt-get install -y git


### PR DESCRIPTION
This PR changes the CUDA image to use the `nvidia/cuda:10.2-devel-ubuntu18.04` tag instead of `nvidia/cuda:latest`. The `nvidia/cuda:latest` tag requires CUDA 11 support, wheras the dpcpp-cuda project requires only CUDA 10.2 support.